### PR TITLE
feat: improve AI agents framework and add new skills/subagents

### DIFF
--- a/.agents/skills/api-tester.md
+++ b/.agents/skills/api-tester.md
@@ -1,0 +1,26 @@
+# Skill: API Tester
+
+Validates API endpoint responses against expected status codes and JSON schemas by curling the running backend.
+
+## 📖 Description
+
+This skill tests the health and correctness of all public API endpoints. It checks that endpoints return HTTP 200 (or 401 for protected routes) and that responses are valid JSON. Essential to run after any backend changes to ensure the API surface remains functional.
+
+## 🛠 Usage
+
+Agents should invoke this skill after implementing new endpoints or modifying existing ones.
+
+**Command**:
+```bash
+./.agents/skills/test_api.sh
+```
+
+## 🎯 Expected Outcome
+
+- **Success**: All endpoints return expected status codes and valid JSON responses.
+- **Failure**: Specific endpoint failures are reported with HTTP status codes, indicating connectivity issues or broken endpoints.
+
+## ⚠️ Requirements
+
+- The backend must be running (e.g., `make dev-up` or `docker compose -f deployments/docker-compose-dev.yaml up -d backend`).
+- Environment variable `API_BASE_URL` can override the default `http://localhost:8000`.

--- a/.agents/skills/scan_security.sh
+++ b/.agents/skills/scan_security.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# .agents/skills/scan_security.sh
+# Runs pre-commit security hooks and security-focused tests.
+
+set -e
+
+echo "🔒 Running Security Scan..."
+
+# 1. Run pre-commit security hooks on backend
+echo ""
+echo "📍 Running pre-commit hooks..."
+cd backend && poetry run pre-commit run --all-files --show-diff-on-failure
+
+if [ $? -eq 0 ]; then
+    echo "✅ Pre-commit hooks passed."
+else
+    echo "❌ Pre-commit hooks failed!"
+    exit 1
+fi
+
+# 2. Run security-specific tests
+echo ""
+echo "📍 Running security tests..."
+make test-app || {
+    echo "❌ Security tests failed!"
+    exit 1
+}
+
+echo ""
+echo "🚀 Security scan completed successfully!"

--- a/.agents/skills/security-scan.md
+++ b/.agents/skills/security-scan.md
@@ -1,0 +1,27 @@
+# Skill: Security Scan
+
+Runs pre-commit security hooks and security-focused tests to ensure the codebase meets security standards.
+
+## 📖 Description
+
+This skill performs a security audit of the codebase by running pre-commit hooks (trailing whitespace, YAML validation, large file checks) and executing security-specific pytest suites. Essential to run before committing changes or before CI/CD pipeline execution.
+
+## 🛠 Usage
+
+Agents should invoke this skill before committing any code changes or when security is a concern.
+
+**Command**:
+```bash
+./.agents/skills/scan_security.sh
+```
+
+## 🎯 Expected Outcome
+
+- **Success**: Pre-commit hooks pass and security tests (`test_security.py`) return green.
+- **Failure**: Specific hook or test failures are reported, indicating security concerns or code quality issues.
+
+## ⚠️ Requirements
+
+- Docker must be installed and running.
+- Poetry must be configured in `backend/pyproject.toml`.
+- The test database must be available (`make test-db-up`).

--- a/.agents/skills/test_api.sh
+++ b/.agents/skills/test_api.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# .agents/skills/test_api.sh
+# Validates API endpoint responses against expected status codes and schemas.
+
+set -e
+
+BASE_URL="${API_BASE_URL:-http://localhost:8000}"
+
+echo "🔌 Testing API Endpoints..."
+echo "   Base URL: $BASE_URL"
+
+FAILED=0
+
+# Test 1: Health check / root endpoint
+echo ""
+echo "📍 Testing GET / ..."
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/" 2>/dev/null || echo "000")
+if [ "$RESPONSE" = "200" ]; then
+    echo "   ✅ GET / → 200 OK"
+else
+    echo "   ❌ GET / → $RESPONSE (expected 200)"
+    FAILED=1
+fi
+
+# Test 2: Posts listing
+echo ""
+echo "📍 Testing GET /api/posts ..."
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/posts" 2>/dev/null || echo "000")
+if [ "$RESPONSE" = "200" ] || [ "$RESPONSE" = "401" ]; then
+    echo "   ✅ GET /api/posts → $RESPONSE"
+    BODY=$(curl -s "$BASE_URL/api/posts" 2>/dev/null || echo "{}")
+    if echo "$BODY" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+        echo "   ✅ Response is valid JSON"
+    else
+        echo "   ⚠️  Response is not valid JSON"
+    fi
+else
+    echo "   ❌ GET /api/posts → $RESPONSE (expected 200 or 401)"
+    FAILED=1
+fi
+
+# Test 3: Users listing
+echo ""
+echo "📍 Testing GET /api/users ..."
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/users" 2>/dev/null || echo "000")
+if [ "$RESPONSE" = "200" ] || [ "$RESPONSE" = "401" ]; then
+    echo "   ✅ GET /api/users → $RESPONSE"
+else
+    echo "   ❌ GET /api/users → $RESPONSE (expected 200 or 401)"
+    FAILED=1
+fi
+
+# Test 4: OpenAPI schema
+echo ""
+echo "📍 Testing GET /docs (OpenAPI) ..."
+RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/docs" 2>/dev/null || echo "000")
+if [ "$RESPONSE" = "200" ]; then
+    echo "   ✅ GET /docs → 200 OK"
+else
+    echo "   ⚠️  GET /docs → $RESPONSE (expected 200)"
+fi
+
+echo ""
+if [ $FAILED -eq 0 ]; then
+    echo "🚀 All API tests passed!"
+    exit 0
+else
+    echo "❌ Some API tests failed. Is the backend running?"
+    echo "   Start with: make dev-up"
+    exit 1
+fi

--- a/.agents/subagents/backend-architect.md
+++ b/.agents/subagents/backend-architect.md
@@ -1,3 +1,12 @@
+---
+name: backend-architect
+description: Specialized agent for FastAPI architecture, SQLAlchemy models, Alembic migrations, and Pydantic schemas. Use when working on backend code, database models, or API endpoints.
+tools: Read, Grep, Glob, Bash(alembic:*, ruff:*, black:*, pytest:*)
+model: inherit
+permissionMode: default
+maxTurns: 12
+---
+
 # Backend Architect Subagent
 
 Specialized agent for architectural design, code consistency, and best practices in the FastAPI/SQLAlchemy/Pydantic stack of the **fastapi-blog** project.

--- a/.agents/subagents/devops-infra.md
+++ b/.agents/subagents/devops-infra.md
@@ -1,3 +1,12 @@
+---
+name: devops-infra
+description: Specialized agent for Docker, Docker Compose, CI/CD pipelines, Makefile automation, and infrastructure configuration. Use when working on deployment, containers, or CI/CD.
+tools: Read, Grep, Glob, Bash(docker:*, docker-compose:*, make:*)
+model: inherit
+permissionMode: default
+maxTurns: 12
+---
+
 # DevOps & Infra Specialist Subagent
 
 Specialized agent for containerization, local environment orchestration, CI/CD pipelines, and infrastructure-as-code in the **fastapi-blog** project.

--- a/.agents/subagents/frontend-specialist.md
+++ b/.agents/subagents/frontend-specialist.md
@@ -1,3 +1,12 @@
+---
+name: frontend-specialist
+description: Specialized agent for Next.js components, Chakra UI, responsive design, and frontend architecture. Use when working on UI components, pages, or frontend styling.
+tools: Read, Grep, Glob, Bash(eslint:*, prettier:*)
+model: inherit
+permissionMode: default
+maxTurns: 12
+---
+
 # Frontend Specialist Subagent
 
 Specialized agent for UI/UX development, component architecture, and modern web practices using the Next.js and Chakra UI stack in the **fastapi-blog** project.

--- a/.agents/subagents/fullstack-integrator.md
+++ b/.agents/subagents/fullstack-integrator.md
@@ -1,0 +1,43 @@
+---
+name: fullstack-integrator
+description: Handles cross-cutting changes spanning backend and frontend. Use when a task requires coordinated updates to both FastAPI backend and Next.js frontend (e.g., adding fields, modifying API responses, updating data flows).
+tools: Read, Grep, Glob, Bash(alembic:*, ruff:*, pytest:*, eslint:*, make:*)
+model: inherit
+permissionMode: default
+maxTurns: 15
+---
+
+# Fullstack Integrator Subagent
+
+Specialized agent for coordinating changes that span both the FastAPI backend and Next.js frontend in the **fastapi-blog** project.
+
+## 🎯 Domain Expertise
+
+- **Cross-Stack Coordination**: Ensures backend model/schema changes are reflected in frontend components and API consumers.
+- **Data Flow Mapping**: Traces how data moves from database → SQLAlchemy model → Pydantic schema → FastAPI endpoint → Next.js page/component.
+- **Migration Management**: Coordinates Alembic migrations with frontend display updates.
+
+## 🛠 Project Standards
+
+- **Backend Changes**:
+    - `models/`: SQLAlchemy entities must match database schema.
+    - `schemas/`: Pydantic DTOs must expose all fields the frontend needs.
+    - `routers/`: API endpoints must return schemas that align with frontend expectations.
+    - `migrations/`: Every model change requires an Alembic migration.
+
+- **Frontend Changes**:
+    - `pages/`: Must consume API responses using the correct schema shapes.
+    - `components/`: Must display data consistent with backend model fields.
+    - `lib/`: Data fetching logic must handle updated API response structures.
+
+## 📜 Operational Guidelines
+
+1. **Identify Impact**: When a change is requested, map all affected layers (model → schema → router → frontend page → component).
+2. **Backend First**: Always implement backend changes first (model, schema, migration, endpoint), then update frontend consumers.
+3. **Schema Alignment**: Verify that Pydantic schemas expose exactly what the frontend needs — no more, no less.
+4. **Migration Safety**: Generate and apply migrations before updating frontend code that depends on new fields.
+5. **Validation**: Run `make pre-commit` and `make test-app` after backend changes, then verify frontend with ESLint.
+
+## 💬 Invocation Example
+
+"I want to add a 'tags' field to posts. Please update the backend model, schema, migration, API endpoint, and the frontend post display component."

--- a/.agents/subagents/observability-expert.md
+++ b/.agents/subagents/observability-expert.md
@@ -1,3 +1,12 @@
+---
+name: observability-expert
+description: Specialized agent for OpenTelemetry, Jaeger, Zipkin, Prometheus, and observability pipeline configuration. Use when troubleshooting traces, metrics, or telemetry setup.
+tools: Read, Grep, Glob, Bash(otel-collector:*)
+model: inherit
+permissionMode: default
+maxTurns: 12
+---
+
 # Observability Expert Subagent
 
 Specialized agent for monitoring, tracing, and metrics management in the **fastapi-blog** project, focusing on OpenTelemetry (OTLP) and the observability stack (Jaeger, Zipkin, Prometheus).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,44 +2,69 @@
 
 This file and the `.agents/` directory define the operational framework for AI agents interacting with the **fastapi-blog** project.
 
-## 🤖 Framework Structure
+## Framework Structure
 
-- **`.agents/skills/`**: Contains specialized tool definitions, scripts, and executable logic that extend the agent's core capabilities.
-- **`.agents/subagents/`**: Defines specialized agent personas with focused system prompts and tailored toolsets for specific domains (e.g., Backend, Frontend, DevOps).
+- **`.agents/skills/`**: Project-specific automation skills with executable scripts.
+- **`.agents/skills-packages/`**: Agent Skills Open Standard packages (distributable).
+- **`.agents/subagents/`**: Specialized agent personas with restricted tool access.
 
-## 🛠 Project Blueprint
+## Project Blueprint
 
 ### Backend (Python/FastAPI)
-- **Stack**: Python 3.13, Poetry, SQLAlchemy, Alembic, Pydantic.
+- **Stack**: Python 3.13, Poetry, SQLAlchemy 2.0, Alembic, Pydantic v2.
 - **Key Files**: `backend/app/main.py`, `backend/pyproject.toml`.
-- **Database**: PostgreSQL (managed via SQLAlchemy models in `backend/app/models/`).
+- **Models**: `backend/app/models/` — SQLAlchemy entities.
+- **Schemas**: `backend/app/schemas/` — Pydantic DTOs.
+- **Services**: `backend/app/services/` — Business logic.
+- **Routers**: `backend/app/routers/` — API endpoints.
 
 ### Frontend (Next.js/React)
-- **Stack**: React, Next.js, Yarn, Vanilla CSS.
+- **Stack**: React, Next.js (v12), Yarn, Chakra UI, Vanilla CSS.
 - **Key Files**: `frontend/pages/index.js`, `frontend/package.json`.
+- **Linting**: ESLint + Prettier (`frontend/.eslintrc.json`).
 
 ### Infrastructure & Observability
 - **Containerization**: Docker & Docker Compose (`deployments/`).
 - **Telemetry**: OpenTelemetry (OTLP), Jaeger, Zipkin, Prometheus.
+- **CI/CD**: GitHub Actions (`.github/workflows/`).
 
-## 📜 Agent Guidelines
+## Agent Guidelines
 
-1. **Empirical Research**: Before any implementation, use `grep_search` and `read_file` to confirm current logic. Do not rely solely on memory.
+1. **Empirical Research**: Before any implementation, use `grep` and `read_file` to confirm current logic. Do not rely solely on memory.
 2. **Atomic Changes**: Keep PRs and commits focused. One feature or fix per cycle.
-3. **Validation Mandatory**: Every code change must be followed by a verification step (test execution or manual verification script).
-4. **Dependency Management**: Use the provided Docker environments to run commands like `poetry lock` or `npm install` if local tools are missing.
+3. **Validation Mandatory**: Every code change must be followed by a verification step (tests, linters, or manual verification script).
+4. **Dependency Management**: Use Docker environments to run `poetry lock` or `yarn install` if local tools are missing.
+5. **Read-Only Subagents**: Subagents analyze and validate but do not write code. The main agent handles all code modifications.
 
-## 🧩 Custom Skills (Coming Soon)
+## Skills
 
-Custom skills located in `.agents/skills/` allow for project-specific automation:
-- **`migration-check`**: Validates Alembic migration integrity.
-- **`telemetry-verify`**: Checks if OTLP exporters are correctly configured.
+### `.agents/skills/` (Executable Scripts)
+- **`migration-validator`** — Validates Alembic migration integrity (`check_migrations.sh`).
+- **`telemetry-tester`** — Verifies OTLP exporter connectivity (`test_telemetry.sh`).
+- **`dependencies-sync`** — Synchronizes Poetry and Yarn lockfiles (`sync_deps.sh`).
+- **`api-tester`** — Validates API endpoint responses (`test_api.sh`).
+- **`security-scan`** — Runs security hooks and tests (`scan_security.sh`).
 
-## 👥 Subagents (Coming Soon)
+### `.agents/skills-packages/` (Open Standard)
+- **`clean-code-refactorer`** — Refactoring with SOLID/DRY principles.
+- **`xp-copilot`** — TDD and Extreme Programming workflow.
 
-Invoke specialized agents for complex investigations:
-- **`backend-specialist`**: Expert in FastAPI performance and DB schema design.
-- **`frontend-specialist`**: Expert in React state management and responsive design.
+## Subagents
+
+Invoke specialized agents for complex investigations. All subagents have **restricted tool access** (read-only + specific commands):
+
+- **`backend-architect`** — FastAPI architecture, SQLAlchemy models, Alembic migrations.
+- **`frontend-specialist`** — Next.js components, Chakra UI, responsive design.
+- **`devops-infra`** — Docker, Docker Compose, CI/CD pipelines, Makefile automation.
+- **`observability-expert`** — OpenTelemetry, Jaeger, Zipkin, Prometheus.
+- **`fullstack-integrator`** — Cross-cutting changes spanning backend and frontend.
+
+## Verification Commands
+
+```bash
+make pre-commit    # Run ruff, black, and pre-commit hooks on backend
+make test-app      # Run pytest with coverage in Docker test environment
+```
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
 ## Beads Issue Tracker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides instructions and context for AI coding agents working on this project.
 
+For complete agent framework, subagents, skills, and workflow protocols, see **[AGENTS.md](AGENTS.md)**.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
 ## Beads Issue Tracker
 
@@ -50,21 +52,35 @@ bd close <id>         # Complete work
 - If push fails, resolve and retry until it succeeds
 <!-- END BEADS INTEGRATION -->
 
-
 ## Build & Test
 
-_Add your build and test commands here_
-
 ```bash
-# Example:
-# npm install
-# npm test
+# Start development environment
+make dev-up
+
+# Run backend tests with coverage
+make test-app
+
+# Run pre-commit hooks (ruff, black)
+make pre-commit
+
+# Generate Alembic migration
+make migrate
 ```
 
 ## Architecture Overview
 
-_Add a brief overview of your project architecture_
+- **Backend**: FastAPI + SQLAlchemy 2.0 + Pydantic v2 + PostgreSQL
+- **Frontend**: Next.js v12 + React + Chakra UI
+- **Infrastructure**: Docker Compose, GitHub Actions, OpenTelemetry
+- **Observability**: Jaeger, Zipkin, Prometheus via OTLP collector
 
 ## Conventions & Patterns
 
-_Add your project-specific conventions here_
+- Use `async/await` for database operations
+- Keep business logic in `services/`, not in `routers/`
+- Every Model change needs corresponding Schema + Alembic migration
+- Prioritize Chakra UI components over raw CSS
+- Run `make pre-commit` before committing
+- Invoke specialized subagents from `.agents/subagents/` for complex tasks
+- Use skills from `.agents/skills/` for project-specific automation

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,6 +16,6 @@ O arquivo `AGENTS.md` é a fonte da verdade para:
 
 1. **Pesquisa Empírica**: Sempre utilize `grep_search` e `read_file` para validar o estado atual do código antes de propor mudanças, conforme definido no blueprint do projeto.
 2. **Uso de Subagentes**: Quando a tarefa for complexa, utilize o subagente especializado correspondente definido em `.agents/subagents/`.
-3. **Validação com Skills**: Utilize as skills oficiais em `.agents/dist/` (instalando-as via `gemini skills install`) para garantir que os padrões de qualidade (TDD, Clean Code, Migrations) sejam mantidos.
+3. **Validação com Skills**: Utilize as skills oficiais em `.agents/skills/` (instalando-as via `gemini skills install`) para garantir que os padrões de qualidade (TDD, Clean Code, Migrations) sejam mantidos.
 
 Qualquer conflito entre estas instruções e as ferramentas deve ser resolvido em favor das diretrizes do `AGENTS.md`.


### PR DESCRIPTION
## Changes

- **New skills**: `api-tester` (validates API endpoints), `security-scan` (runs security hooks/tests)
- **New subagent**: `fullstack-integrator` (cross-cutting backend+frontend changes)
- **Updated subagents**: Added YAML frontmatter headers with tool restrictions and metadata to `backend-architect`, `devops-infra`, `frontend-specialist`, `observability-expert`
- **Documentation**: Refined `AGENTS.md` and `CLAUDE.md` with clearer project blueprint, verification commands, and operational guidelines
- **Agent docs**: Updated `GEMINI.md` to reference correct skills directory